### PR TITLE
Added context support

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2022 RandLabs
+   Copyright 2019-2023 RandLabs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Golang implementation of a rundown protection for accessing a shared object.
 
-Some times we need to access a shared resource than can be created and deleted by a routine we don't control. Or the opposite, we know when we create and delete the resource but we don't control when it is accessed.
+Some times we need to access a shared resource than can be created and deleted by a routine we don't control. Or the
+opposite, we know when we create and delete the resource but we don't control when it is accessed.
 
-Unlike `sync.WaitGroup`, this library does not panic if you try to access an unavailable resource. Just check the return `Acquire` method to ensure if you can safely use the resource.
+Unlike `sync.WaitGroup`, this library does not panic if you try to access an unavailable resource. Just check the return
+`Acquire` method to ensure if you can safely use the resource.
 
 ## Usage
 
@@ -33,9 +35,8 @@ if r.Acquire() {
 }
 ```
 
-
 Run demo: `go run ./_examples/demo.go`
 
 ## License
 
-[Apache](/LICENSE)
+[Apache](/LICENSE.txt)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/randlabs/rundown-protection
 
-go 1.13
+go 1.18


### PR DESCRIPTION
Now, the rundown protection object can be used as a cancellable context. When the `Wait` method is executed, the embedded context will be cancelled.